### PR TITLE
Lint smart contracts according to conventions

### DIFF
--- a/network-contracts/contracts/KeycardWallet.sol
+++ b/network-contracts/contracts/KeycardWallet.sol
@@ -1,190 +1,196 @@
-pragma solidity ^0.5.0;
+pragma solidity >0.5.0 <0.7.0;
 pragma experimental ABIEncoderV2;
 
-import './KeycardWalletFactory.sol';
+import "./KeycardWalletFactory.sol";
 
 contract KeycardWallet {
-  event TopUp(address from, uint256 value);
-  event NewPaymentRequest(uint256 blockNumber, address to, uint256 amount);
-  event NewWithdrawal(address to, uint256 value);
+    event TopUp(address from, uint256 value);
+    event NewPaymentRequest(uint256 blockNumber, address to, uint256 amount);
+    event NewWithdrawal(address to, uint256 value);
 
-  //TODO: replace with chainid opcode
-  uint256 constant chainId = 1;
+    //TODO: replace with chainid opcode
+    uint256 constant chainId = 1;
 
-  // must be less than 256, because the hash of older blocks cannot be retrieved
-  uint256 constant maxTxDelayInBlocks = 10;
+    // must be less than 256, because the hash of older blocks cannot be retrieved
+    uint256 constant maxTxDelayInBlocks = 10;
 
-  struct Payment {
-    uint256 blockNumber;
-    bytes32 blockHash;
-    uint256 amount;
-    address to;
-  }
-
-  bytes32 constant EIP712DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
-  bytes32 constant PAYMENT_TYPEHASH = keccak256("Payment(uint256 blockNumber,bytes32 blockHash,uint256 amount,address to)");
-  bytes32 DOMAIN_SEPARATOR;
-
-  address public register;
-  address public owner;
-  address public keycard;
-  Settings public settings;
-  mapping(address => uint) public pendingWithdrawals;
-  uint256 public totalPendingWithdrawals;
-  uint256 public lastUsedBlockNum;
-
-  struct Settings {
-    uint256 maxTxValue;
-    uint256 minBlockDistance;
-  }
-
-  modifier onlyOwner() {
-    require(msg.sender == owner, "owner required");
-    _;
-  }
-
-  // anyone can add funds to the wallet
-  function () external payable {
-    emit TopUp(msg.sender, msg.value);
-  }
-
-  constructor(address _owner, address _keycard, Settings memory _settings, address _register) public {
-    owner = _owner == address(0) ? msg.sender : _owner;
-    keycard = _keycard;
-    register = address(0);
-
-    settings = _settings;
-    _setRegister(_register);
-    totalPendingWithdrawals = 0;
-    lastUsedBlockNum = block.number;
-  }
-
-  function _setRegister(address _register) internal {
-    if (register != address(0)) {
-      KeycardWalletFactory(uint160(register)).unregister(owner, keycard);
+    struct Payment {
+        uint256 blockNumber;
+        bytes32 blockHash;
+        uint256 amount;
+        address to;
     }
 
-    if (_register != address(0) && msg.sender != _register) {
-      KeycardWalletFactory(uint160(_register)).register(owner, keycard);
+    bytes32 constant EIP712DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 constant PAYMENT_TYPEHASH = keccak256("Payment(uint256 blockNumber,bytes32 blockHash,uint256 amount,address to)");
+    bytes32 DOMAIN_SEPARATOR;
+
+    address public register;
+    address public owner;
+    address public keycard;
+    Settings public settings;
+    mapping(address => uint) public pendingWithdrawals;
+    uint256 public totalPendingWithdrawals;
+    uint256 public lastUsedBlockNum;
+
+    struct Settings {
+        uint256 maxTxValue;
+        uint256 minBlockDistance;
     }
 
-    register = _register;
-
-    DOMAIN_SEPARATOR = keccak256(abi.encode(
-      EIP712DOMAIN_TYPEHASH,
-      keccak256("KeycardWallet"),
-      keccak256("1"),
-      chainId,
-      register
-    ));
-  }
-
-  function setRegister(address _register) public onlyOwner {
-    _setRegister(_register);
-  }
-
-  function setOwner(address _owner) public onlyOwner {
-    if (register != address(0)) {
-      KeycardWalletFactory(uint160(register)).setOwner(owner, _owner);
+    modifier onlyOwner() {
+        require(msg.sender == owner, "owner required");
+        _;
     }
 
-    owner = _owner;
-  }
-
-  function setKeycard(address _keycard) public onlyOwner {
-    if (register != address(0)) {
-      KeycardWalletFactory(uint160(register)).setKeycard(keycard, _keycard);
+    // anyone can add funds to the wallet
+    function () external payable {
+        emit TopUp(msg.sender, msg.value);
     }
 
-    keycard = _keycard;
-  }
+    constructor(address _owner, address _keycard, Settings memory _settings, address _register) public {
+        owner = _owner == address(0) ? msg.sender : _owner;
+        keycard = _keycard;
+        register = address(0);
 
-  function setSettings(Settings memory _settings) public onlyOwner {
-    settings = _settings;
-  }
-
-  function hash(Payment memory _payment) internal pure returns (bytes32) {
-    return keccak256(abi.encode(
-      PAYMENT_TYPEHASH,
-      _payment.blockNumber,
-      _payment.blockHash,
-      _payment.amount,
-      _payment.to
-    ));
-  }
-
-  function verify(Payment memory _payment, bytes memory _sig) internal view returns (bool) {
-    require(_sig.length == 65, "bad signature length");
-
-    bytes32 r;
-    bytes32 s;
-    uint8 v;
-
-    assembly {
-      r := mload(add(_sig, 32))
-      s := mload(add(_sig, 64))
-      v := byte(0, mload(add(_sig, 96)))
+        settings = _settings;
+        _setRegister(_register);
+        totalPendingWithdrawals = 0;
+        lastUsedBlockNum = block.number;
     }
 
-    if (v < 27) {
-      v += 27;
+    function _setRegister(address _register) internal {
+        if (register != address(0)) {
+            KeycardWalletFactory(uint160(register)).unregister(owner, keycard);
+        }
+
+        if (_register != address(0) && msg.sender != _register) {
+            KeycardWalletFactory(uint160(_register)).register(owner, keycard);
+        }
+
+        register = _register;
+
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                EIP712DOMAIN_TYPEHASH,
+                keccak256("KeycardWallet"),
+                keccak256("1"),
+                chainId,
+                register
+            )
+        );
     }
 
-    require(v == 27 || v == 28, "signature version doesn't match");
+    function setRegister(address _register) public onlyOwner {
+        _setRegister(_register);
+    }
 
-    bytes32 digest = keccak256(abi.encodePacked(
-        "\x19\x01",
-        DOMAIN_SEPARATOR,
-        hash(_payment)
-    ));
+    function setOwner(address _owner) public onlyOwner {
+        if (register != address(0)) {
+            KeycardWalletFactory(uint160(register)).setOwner(owner, _owner);
+        }
 
-    return ecrecover(digest, v, r, s) == keycard;
-  }
+        owner = _owner;
+    }
 
-  function requestPayment(Payment memory _payment, bytes memory _signature) public {
-    // check that a keycard address has been set
-    require(keycard != address(0), "keycard address not set");
+    function setKeycard(address _keycard) public onlyOwner {
+        if (register != address(0)) {
+            KeycardWalletFactory(uint160(register)).setKeycard(keycard, _keycard);
+        }
 
-    // verify the signer
-    require(verify(_payment, _signature), "signer is not the keycard");
+        keycard = _keycard;
+    }
 
-    // check that the block number used for signing is less than the block number
-    require(_payment.blockNumber < block.number, "transaction cannot be in the future");
+    function setSettings(Settings memory _settings) public onlyOwner {
+        settings = _settings;
+    }
 
-    // check that the block number used is not too old
-    require(_payment.blockNumber >= (block.number - maxTxDelayInBlocks), "transaction too old");
+    function hash(Payment memory _payment) internal pure returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                PAYMENT_TYPEHASH,
+                _payment.blockNumber,
+                _payment.blockHash,
+                _payment.amount,
+                _payment.to
+            )
+        );
+    }
 
-    // check that the block number is not too near to the last one in which a tx has been processed
-    require(_payment.blockNumber >= (lastUsedBlockNum + settings.minBlockDistance), "cooldown period not expired yet");
+    function verify(Payment memory _payment, bytes memory _sig) internal view returns (bool) {
+        require(_sig.length == 65, "bad signature length");
 
-    // check that the blockHash is valid
-    require(_payment.blockHash == blockhash(_payment.blockNumber), "invalid block hash");
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
 
-    // check that _payment.amount is not greater than settings.maxTxValue
-    require(_payment.amount <= settings.maxTxValue, "amount not allowed");
+        assembly {
+            r := mload(add(_sig, 32))
+            s := mload(add(_sig, 64))
+            v := byte(0, mload(add(_sig, 96)))
+        }
 
-    int256 availableBalance = int256(address(this).balance - totalPendingWithdrawals - _payment.amount);
-    // check that balance is enough for this payment
-    require(availableBalance >= 0, "balance is not enough");
+        if (v < 27) {
+            v += 27;
+        }
 
-    // set new baseline block for checks
-    lastUsedBlockNum = block.number;
+        require(v == 27 || v == 28, "signature version doesn't match");
 
-    // add pendingWithdrawal
-    totalPendingWithdrawals += _payment.amount;
-    pendingWithdrawals[_payment.to] += _payment.amount;
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                hash(_payment)
+            )
+        );
 
-    emit NewPaymentRequest(_payment.blockNumber, _payment.to, _payment.amount);
-  }
+        return ecrecover(digest, v, r, s) == keycard;
+    }
 
-  function withdraw() public {
-    uint256 amount = pendingWithdrawals[msg.sender];
-    require(amount > 0, "no pending withdrawal");
+    function requestPayment(Payment memory _payment, bytes memory _signature) public {
+        // check that a keycard address has been set
+        require(keycard != address(0), "keycard address not set");
 
-    pendingWithdrawals[msg.sender] = 0;
-    totalPendingWithdrawals -= amount;
+        // verify the signer
+        require(verify(_payment, _signature), "signer is not the keycard");
 
-    msg.sender.transfer(amount);
-    emit NewWithdrawal(msg.sender, amount);
-  }
+        // check that the block number used for signing is less than the block number
+        require(_payment.blockNumber < block.number, "transaction cannot be in the future");
+
+        // check that the block number used is not too old
+        require(_payment.blockNumber >= (block.number - maxTxDelayInBlocks), "transaction too old");
+
+        // check that the block number is not too near to the last one in which a tx has been processed
+        require(_payment.blockNumber >= (lastUsedBlockNum + settings.minBlockDistance), "cooldown period not expired yet");
+
+        // check that the blockHash is valid
+        require(_payment.blockHash == blockhash(_payment.blockNumber), "invalid block hash");
+
+        // check that _payment.amount is not greater than settings.maxTxValue
+        require(_payment.amount <= settings.maxTxValue, "amount not allowed");
+
+        int256 availableBalance = int256(address(this).balance - totalPendingWithdrawals - _payment.amount);
+        // check that balance is enough for this payment
+        require(availableBalance >= 0, "balance is not enough");
+
+        // set new baseline block for checks
+        lastUsedBlockNum = block.number;
+
+        // add pendingWithdrawal
+        totalPendingWithdrawals += _payment.amount;
+        pendingWithdrawals[_payment.to] += _payment.amount;
+
+        emit NewPaymentRequest(_payment.blockNumber, _payment.to, _payment.amount);
+    }
+
+    function withdraw() public {
+        uint256 amount = pendingWithdrawals[msg.sender];
+        require(amount > 0, "no pending withdrawal");
+
+        pendingWithdrawals[msg.sender] = 0;
+        totalPendingWithdrawals -= amount;
+
+        msg.sender.transfer(amount);
+        emit NewWithdrawal(msg.sender, amount);
+    }
 }

--- a/network-contracts/contracts/KeycardWalletFactory.sol
+++ b/network-contracts/contracts/KeycardWalletFactory.sol
@@ -1,73 +1,73 @@
-pragma solidity ^0.5.0;
+pragma solidity >0.5.0 <0.7.0;
 pragma experimental ABIEncoderV2;
 
-import './KeycardWallet.sol';
+import "./KeycardWallet.sol";
 
 contract KeycardWalletFactory {
-  mapping(address => address) public ownersWallets;
-  mapping(address => address) public keycardsWallets;
+    mapping(address => address) public ownersWallets;
+    mapping(address => address) public keycardsWallets;
 
-  event NewWallet(
-    KeycardWallet wallet
-  );
+    event NewWallet(
+        KeycardWallet wallet
+    );
 
-  function create(address keycard, KeycardWallet.Settings memory settings, bool keycardIsOwner) public {
-    address owner = keycardIsOwner ? keycard : msg.sender;
+    function create(address keycard, KeycardWallet.Settings memory settings, bool keycardIsOwner) public {
+        address owner = keycardIsOwner ? keycard : msg.sender;
 
-    require(ownersWallets[owner] == address(0), "the owner already has a wallet");
-    require(keycardsWallets[keycard] == address(0), "the keycard is already associated to a wallet");
+        require(ownersWallets[owner] == address(0), "the owner already has a wallet");
+        require(keycardsWallets[keycard] == address(0), "the keycard is already associated to a wallet");
 
-    KeycardWallet wallet = new KeycardWallet(owner, keycard, settings, address(this));
-    ownersWallets[owner] = address(wallet);
-    keycardsWallets[keycard] = address(wallet);
-    emit NewWallet(wallet);
-  }
+        KeycardWallet wallet = new KeycardWallet(owner, keycard, settings, address(this));
+        ownersWallets[owner] = address(wallet);
+        keycardsWallets[keycard] = address(wallet);
+        emit NewWallet(wallet);
+    }
 
-  function setOwner(address _oldOwner, address _newOwner) public {
-    address wallet = ownersWallets[_oldOwner];
+    function setOwner(address _oldOwner, address _newOwner) public {
+        address wallet = ownersWallets[_oldOwner];
 
-    require(wallet == msg.sender, "only the registered wallet can call this");
-    require(ownersWallets[_newOwner] == address(0), "the new owner already has a wallet");
+        require(wallet == msg.sender, "only the registered wallet can call this");
+        require(ownersWallets[_newOwner] == address(0), "the new owner already has a wallet");
 
-    ownersWallets[_newOwner] = wallet;
-    delete ownersWallets[_oldOwner];
-  }
+        ownersWallets[_newOwner] = wallet;
+        delete ownersWallets[_oldOwner];
+    }
 
-  function setKeycard(address _oldKeycard, address _newKeycard) public {
-    address wallet = keycardsWallets[_oldKeycard];
+    function setKeycard(address _oldKeycard, address _newKeycard) public {
+        address wallet = keycardsWallets[_oldKeycard];
 
-    require(wallet == msg.sender, "only the registered wallet can call this");
-    require(keycardsWallets[_newKeycard] == address(0), "the keycard already has a wallet");
+        require(wallet == msg.sender, "only the registered wallet can call this");
+        require(keycardsWallets[_newKeycard] == address(0), "the keycard already has a wallet");
 
-    keycardsWallets[_newKeycard] = wallet;
-    delete keycardsWallets[_oldKeycard];
-  }
+        keycardsWallets[_newKeycard] = wallet;
+        delete keycardsWallets[_oldKeycard];
+    }
 
-  function unregister(address _keycard) public {
-    address wallet = ownersWallets[msg.sender];
+    function unregister(address _keycard) public {
+        address wallet = ownersWallets[msg.sender];
 
-    require(wallet != address(0), "the sender has no wallet");
-    require(wallet == keycardsWallets[_keycard], "owner required");
+        require(wallet != address(0), "the sender has no wallet");
+        require(wallet == keycardsWallets[_keycard], "owner required");
 
-    delete ownersWallets[msg.sender];
-    delete keycardsWallets[_keycard];
-  }
+        delete ownersWallets[msg.sender];
+        delete keycardsWallets[_keycard];
+    }
 
-  function unregister(address _owner, address _keycard) public {
-    address wallet = ownersWallets[_owner];
+    function unregister(address _owner, address _keycard) public {
+        address wallet = ownersWallets[_owner];
 
-    require(wallet == msg.sender, "only the registered wallet can call this");
-    require(wallet == keycardsWallets[_keycard], "only the associated keycard can be deassociated");
+        require(wallet == msg.sender, "only the registered wallet can call this");
+        require(wallet == keycardsWallets[_keycard], "only the associated keycard can be deassociated");
 
-    delete ownersWallets[_owner];
-    delete keycardsWallets[_keycard];
-  }
+        delete ownersWallets[_owner];
+        delete keycardsWallets[_keycard];
+    }
 
-  function register(address _owner, address _keycard) public {
-    require(ownersWallets[_owner] == address(0), "the sender already has a wallet");
-    require(keycardsWallets[_keycard] == address(0), "the keycard already has a wallet");
+    function register(address _owner, address _keycard) public {
+        require(ownersWallets[_owner] == address(0), "the sender already has a wallet");
+        require(keycardsWallets[_keycard] == address(0), "the keycard already has a wallet");
 
-    ownersWallets[_owner] = msg.sender;
-    keycardsWallets[_keycard] = msg.sender;
-  }
+        ownersWallets[_owner] = msg.sender;
+        keycardsWallets[_keycard] = msg.sender;
+    }
 }

--- a/network-contracts/contracts/MerchantsRegistry.sol
+++ b/network-contracts/contracts/MerchantsRegistry.sol
@@ -1,27 +1,27 @@
-pragma solidity ^0.5.0;
+pragma solidity >0.5.0 <0.7.0;
 
 contract MerchantsRegistry {
-  address public owner;
-  mapping(address => bool) public merchants;
+    address public owner;
+    mapping(address => bool) public merchants;
 
-  modifier onlyOwner() {
-    require(msg.sender == owner, "owner required");
-    _;
-  }
+    modifier onlyOwner() {
+        require(msg.sender == owner, "owner required");
+        _;
+    }
 
-  constructor() public {
-    owner = msg.sender;
-  }
+    constructor() public {
+        owner = msg.sender;
+    }
 
-  function setOwner(address newOwner) public onlyOwner {
-    owner = newOwner;
-  }
+    function setOwner(address newOwner) public onlyOwner {
+        owner = newOwner;
+    }
 
-  function addMerchant(address merchantAddress) public onlyOwner {
-    merchants[merchantAddress] = true;
-  }
+    function addMerchant(address merchantAddress) public onlyOwner {
+        merchants[merchantAddress] = true;
+    }
 
-  function removeMerchant(address merchantAddress) public onlyOwner {
-    merchants[merchantAddress] = false;
-  }
+    function removeMerchant(address merchantAddress) public onlyOwner {
+        merchants[merchantAddress] = false;
+    }
 }


### PR DESCRIPTION
Fixes errors in linting according to sollint

- `indentation: Only use indent of 4 spaces.`
- `quotes: "./KeycardWalletFactory.sol": Import statements must use double quotes only.`

Fixes problem with different compilers by allowing a range of versions.