### PR TITLE
Registry as interface

### DIFF
--- a/network-contracts/contracts/KeycardRegistry.sol
+++ b/network-contracts/contracts/KeycardRegistry.sol
@@ -1,0 +1,8 @@
+pragma solidity >=0.5.0 <0.7.0;
+
+interface KeycardRegistry {
+    function register(address _owner, address _keycard) external;
+    function unregister(address _owner, address _keycard) external;
+    function setOwner(address _oldOwner, address _newOwner) external;
+    function setKeycard(address _oldKeycard, address _newKeycard) external;
+}

--- a/network-contracts/contracts/KeycardWallet.sol
+++ b/network-contracts/contracts/KeycardWallet.sol
@@ -1,7 +1,7 @@
 pragma solidity >=0.5.0 <0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "./KeycardWalletFactory.sol";
+import "./KeycardRegistry.sol";
 
 contract KeycardWallet {
   event TopUp(address from, uint256 value);
@@ -61,11 +61,11 @@ contract KeycardWallet {
 
   function _setRegister(address _register) internal {
     if (register != address(0)) {
-      KeycardWalletFactory(uint160(register)).unregister(owner, keycard);
+      KeycardRegistry(register).unregister(owner, keycard);
     }
 
     if (_register != address(0) && msg.sender != _register) {
-      KeycardWalletFactory(uint160(_register)).register(owner, keycard);
+      KeycardRegistry(_register).register(owner, keycard);
     }
 
     register = _register;
@@ -85,7 +85,7 @@ contract KeycardWallet {
 
   function setOwner(address _owner) public onlyOwner {
     if (register != address(0)) {
-      KeycardWalletFactory(uint160(register)).setOwner(owner, _owner);
+      KeycardRegistry(register).setOwner(owner, _owner);
     }
 
     owner = _owner;
@@ -93,7 +93,7 @@ contract KeycardWallet {
 
   function setKeycard(address _keycard) public onlyOwner {
     if (register != address(0)) {
-      KeycardWalletFactory(uint160(register)).setKeycard(keycard, _keycard);
+      KeycardRegistry(register).setKeycard(keycard, _keycard);
     }
 
     keycard = _keycard;

--- a/network-contracts/contracts/KeycardWalletFactory.sol
+++ b/network-contracts/contracts/KeycardWalletFactory.sol
@@ -2,8 +2,9 @@ pragma solidity >=0.5.0 <0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "./KeycardWallet.sol";
+import "./KeycardRegistry.sol";
 
-contract KeycardWalletFactory {
+contract KeycardWalletFactory is KeycardRegistry {
   mapping(address => address[]) public ownersWallets;
   mapping(address => address) public keycardsWallets;
 


### PR DESCRIPTION
moves the function definition needed by the wallet in a separate interface to allow it work with different registry implementations.